### PR TITLE
Be explicit about likely need to "re-join" a group in call for review

### DIFF
--- a/process/charter.html
+++ b/process/charter.html
@@ -399,15 +399,14 @@ Working Group participants are aware of the review.</p>
     asking that a Call for Review be sent to the AC. The request should
     be sent <strong>at least three business days before</strong> the anticipated start
     date of the review. The request must include:
-    <ul>
+    <ol>
       <li>A URI to the proposed charter; this charter is public during the AC review.</li>
       <li>The list of significant changes to a revised charter
-	(per <a href="https://www.w3.org/Consortium/Process/#CharterReview">section "Advisory Committee Review of a Working Group or Interest Group Charter"</a> of the Process Document.). In particular, are there
-	any new deliverables with licensing obligations under the W3C Patent
-	Policy? You may wish to use the <a href="https://www.w3.org/2007/10/htmldiff">html diff tool</a></li>
+	(per <a href="https://www.w3.org/Consortium/Process/#CharterReview">section "Advisory Committee Review of a Working Group or Interest Group Charter"</a> of the Process Document). You may wish to use the <a href="https://www.w3.org/2007/10/htmldiff">html diff tool</a></li>
+	<li>In case of renewal of an existing charter, whether the group scope has changed. E.g., are there any new deliverables with licensing obligations under the W3C Patent Policy? The current group participants would need to re-join the group once the revised charter is approved.</li>
       <li>A recommended review start date and duration (at least 28 days according to <a href="https://www.w3.org/Consortium/Process/#CharterReview">the process document</a>)</li>
       <li>The name of the Team-only mailing list for comments</li>
-    </ul>
+    </ol>
   </li>
 </ul>
 


### PR DESCRIPTION
Per request from a member during the 2019 Second Screen WG charter review. 
Via François Daoust: The members run lengthy legal processes before they can join a group and typically need to re-run that process when that happens. They could start it before the Call for Participation is issued but for that to happen, they need to know beforehand that this will actually be needed.